### PR TITLE
게시판 API 만들기 - Data REST 적용 및 테스트 정의

### DIFF
--- a/project-board/build.gradle
+++ b/project-board/build.gradle
@@ -27,14 +27,19 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
-
+	// lombok
 	compileOnly 'org.projectlombok:lombok'
 	testImplementation 'org.projectlombok:lombok'
 	annotationProcessor 'org.projectlombok:lombok'
-
+	// mariaDB
 	runtimeOnly 'org.mariadb.jdbc:mariadb-java-client'
-	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// H2DB
 	runtimeOnly 'com.h2database:h2'
+	//JPA
+	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
+	// rest repo
+	implementation 'org.springframework.boot:spring-boot-starter-data-rest'
+	implementation 'org.springframework.data:spring-data-rest-hal-explorer'
 }
 
 tasks.named('test') {

--- a/project-board/src/main/java/com/fasecampus/projectboard/repository/ArticleCommentRepository.java
+++ b/project-board/src/main/java/com/fasecampus/projectboard/repository/ArticleCommentRepository.java
@@ -2,6 +2,8 @@ package com.fasecampus.projectboard.repository;
 
 import com.fasecampus.projectboard.domain.ArticleComment;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleCommentRepository extends JpaRepository<ArticleComment, Long> {
 }

--- a/project-board/src/main/java/com/fasecampus/projectboard/repository/ArticleRepository.java
+++ b/project-board/src/main/java/com/fasecampus/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,8 @@ package com.fasecampus.projectboard.repository;
 
 import com.fasecampus.projectboard.domain.Article;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 
+@RepositoryRestResource
 public interface ArticleRepository extends JpaRepository<Article, Long> {
 }

--- a/project-board/src/main/resources/application.yml
+++ b/project-board/src/main/resources/application.yml
@@ -13,6 +13,9 @@ spring:
     url: jdbc:mariadb://localhost:3306/bootex
     username: bootuser
     password: bootuser
+#    url: jdbc:h2:mem:testdb
+#    username: sa
+#    driver-class-name: org.h2.Driver
   jpa:
     defer-datasource-initialization: true
     hibernate.ddl-auto: create
@@ -24,7 +27,10 @@ spring:
       hibernate.default_batch_fetch_size: 100
       database-platform: org.hibernate.dialect.MySQLDialect
   h2.console.enabled: false
-  sql.init.mode: always
+#  sql.init.mode: always
+  data.rest:
+    base-path: /api
+    detection-strategy: annotated
 
 ---
 # yaml 파일은 --- 를 기준으로 새로운 document를 생성할 수 있다.
@@ -34,5 +40,5 @@ spring:
   datasource:
     url: jdbc:h2:mem:board;mode=MariaDB
     driverClassName: org.h2.Driver
-  sql.init.mode: always
+#  sql.init.mode: always
   test.database.replace: none

--- a/project-board/src/test/java/com/fasecampus/projectboard/repository/controller/DataRestTest.java
+++ b/project-board/src/test/java/com/fasecampus/projectboard/repository/controller/DataRestTest.java
@@ -1,0 +1,85 @@
+package com.fasecampus.projectboard.repository.controller;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+//@WebMvcTest
+@DisplayName("Data REST - API 테스트")
+@Transactional
+@AutoConfigureMockMvc
+@SpringBootTest
+public class DataRestTest {
+
+    private final MockMvc mvc;
+
+    public DataRestTest(@Autowired MockMvc mvc) {
+        this.mvc = mvc;
+    }
+
+    @DisplayName("[api] 게시글 레스트 조회")
+    @Test
+    void givenNothing_whenRequestingArticles_thenReturnsArticlesJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticle_thenReturnsArticlesJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles/1"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 댓글 목록 조회")
+    @Test
+    void givenNothing_whenRequestingArticleCommentsFromArticle_thenReturnsArticlesJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articles/1/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 게시글 댓글 목록 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComments_thenReturnsArticlesJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articleComments"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+    @DisplayName("[api] 댓글 단건 조회")
+    @Test
+    void givenNothing_whenRequestingArticleComment_thenReturnsArticlesJsonResponse() throws Exception {
+        // Given
+
+        // When & Then
+        mvc.perform(get("/api/articleComments/1"))
+                .andExpect(status().isOk())
+                .andExpect(MockMvcResultMatchers.content().contentType(MediaType.valueOf("application/hal+json")));
+    }
+
+
+}


### PR DESCRIPTION
게시글, 댓글 데이터는 간편하게 Spring Data REST로 서비스하고, 해당 API들의 존재 여부만 체크하게끔 통합테스트 작성.