### PR TITLE
해시태그 검색 페이지와 관련 기능 구현

### DIFF
--- a/project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/controller/ArticleController.java
@@ -1,5 +1,6 @@
 package com.fastcampus.projectboard.controller;
 
+import com.fastcampus.projectboard.domain.Article;
 import com.fastcampus.projectboard.domain.type.SearchType;
 import com.fastcampus.projectboard.dto.response.ArticleResponse;
 import com.fastcampus.projectboard.dto.response.ArticleWithCommentsResponse;
@@ -51,6 +52,25 @@ public class ArticleController {
         map.addAttribute("articleComments", article.articleCommentsResponse());
 
         return "articles/detail";
+    }
+
+    @GetMapping("/search-hashtag")
+    public String searchHashtag(
+        @RequestParam(required = false) String searchValue,
+        @PageableDefault(size = 10, sort = "createdAt", direction = Sort.Direction.DESC) Pageable pageable,
+        ModelMap map) {
+
+        Page<ArticleResponse> articles = articleService.searchArticlesViaHashtag(searchValue, pageable).map(ArticleResponse::from);
+        List<Integer> barNumbers = paginationService.getPaginationBarNumbers(pageable.getPageNumber(), articles.getTotalPages());
+        List<String> hashtags = articleService.getHashtags();
+
+        map.addAttribute("articles", articles);
+        map.addAttribute("hashtags", hashtags);
+        map.addAttribute("paginationBarNumbers", barNumbers);
+        map.addAttribute("searchType", SearchType.HASHTAG);
+
+
+        return "articles/search-hashtag";
     }
 
 }

--- a/project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/repository/ArticleRepository.java
@@ -2,6 +2,7 @@ package com.fastcampus.projectboard.repository;
 
 import com.fastcampus.projectboard.domain.Article;
 import com.fastcampus.projectboard.domain.QArticle;
+import com.fastcampus.projectboard.repository.querydsl.ArticleRepositoryCustom;
 import com.querydsl.core.types.dsl.DateTimeExpression;
 import com.querydsl.core.types.dsl.StringExpression;
 import org.springframework.data.domain.Page;
@@ -15,6 +16,7 @@ import org.springframework.data.rest.core.annotation.RepositoryRestResource;
 @RepositoryRestResource
 public interface ArticleRepository extends
         JpaRepository<Article, Long>,
+        ArticleRepositoryCustom,
         QuerydslPredicateExecutor<Article>
         ,QuerydslBinderCustomizer<QArticle>
 {

--- a/project-board/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustom.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustom.java
@@ -1,0 +1,8 @@
+package com.fastcampus.projectboard.repository.querydsl;
+
+import java.util.List;
+
+public interface ArticleRepositoryCustom {
+
+    List<String> findAllDistinctHashtags();
+}

--- a/project-board/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/repository/querydsl/ArticleRepositoryCustomImpl.java
@@ -1,0 +1,32 @@
+package com.fastcampus.projectboard.repository.querydsl;
+
+import com.fastcampus.projectboard.domain.Article;
+import com.fastcampus.projectboard.domain.QArticle;
+import com.querydsl.jpa.JPQLQuery;
+import org.springframework.data.jpa.repository.support.QuerydslRepositorySupport;
+
+import java.util.List;
+
+public class ArticleRepositoryCustomImpl extends QuerydslRepositorySupport implements ArticleRepositoryCustom {
+    public ArticleRepositoryCustomImpl() {
+        super(Article.class);       // 생성자에 해당하는 클래스를 넣어주면 됨.
+    }
+
+    @Override
+    public List<String> findAllDistinctHashtags() {
+        QArticle article = QArticle.article;
+
+        return from(article)  // 제네릭은 리턴라입의 제네릭과 일치시킬 것.
+                .distinct()
+                .select(article.hashtag)
+                .where(article.hashtag.isNotNull())
+                .fetch();
+
+//        JPQLQuery<String> query = from(article)  // 제네릭은 리턴라입의 제네릭과 일치시킬 것.
+//                .distinct()
+//                .select(article.hashtag)
+//                .where(article.hashtag.isNotNull());
+//
+//        return query.fetch();       //fetch()?
+    }
+}

--- a/project-board/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/service/ArticleService.java
@@ -13,6 +13,8 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.List;
+
 @Slf4j
 @RequiredArgsConstructor
 @Transactional
@@ -62,4 +64,15 @@ public class ArticleService {
         articleRepository.deleteById(articleId);
     }
 
+    @Transactional(readOnly = true)
+    public Page<ArticleDto> searchArticlesViaHashtag(String hashtag, Pageable pageable) {
+        if(hashtag == null || hashtag.isBlank()) {
+            return Page.empty(pageable);
+        }
+        return articleRepository.findByHashtag(hashtag, pageable).map(ArticleDto::from);
+    }
+
+    public List<String> getHashtags() {
+        return articleRepository.findAllDistinctHashtags();
+    }
 }

--- a/project-board/src/main/resources/templates/articles/search-hashtag.html
+++ b/project-board/src/main/resources/templates/articles/search-hashtag.html
@@ -1,0 +1,83 @@
+<!DOCTYPE html>
+<html lang="ko">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <meta name="description" content="">
+  <meta name="author" content="Uno Kim">
+  <title>해시태그 검색</title>
+
+  <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-0evHe/X+R7YkIZDRvuzKMRqM+OrBnVFBL6DOitfPri4tjfHxaWutUpFmBp4vmVor" crossorigin="anonymous">
+  <link href="/css/articles/table-header.css" rel="stylesheet">
+</head>
+
+<body>
+<header id="header">
+  헤더 삽입부
+  <hr>
+</header>
+
+<main class="container">
+  <header class="py-5 text-center">
+    <h1>Hashtags</h1>
+  </header>
+
+  <section class="row">
+    <div id="hashtags" class="col-9 d-flex flex-wrap justify-content-evenly">
+      <div class="p-2">
+        <h2 class="text-center lh-lg font-monospace"><a href="#">#java</a></h2>
+      </div>
+    </div>
+  </section>
+
+  <hr>
+
+  <table class="table" id="article-table">
+    <thead>
+    <tr>
+      <th class="title col-6"><a>제목</a></th>
+      <th class="content col-4"><a>본문</a></th>
+      <th class="user-id"><a>작성자</a></th>
+      <th class="created-at"><a>작성일</a></th>
+    </tr>
+    </thead>
+    <tbody>
+    <tr>
+      <td class="title"><a>첫글</a></td>
+      <td class="content"><span class="d-inline-block text-truncate" style="max-width: 300px;">본문</span></td>
+      <td class="user-id">Uno</td>
+      <td class="created-at"><time>2022-01-01</time></td>
+    </tr>
+    <tr>
+      <td>두번째글</td>
+      <td>본문</td>
+      <td>Uno</td>
+      <td><time>2022-01-02</time></td>
+    </tr>
+    <tr>
+      <td>세번째글</td>
+      <td>본문</td>
+      <td>Uno</td>
+      <td><time>2022-01-03</time></td>
+    </tr>
+    </tbody>
+  </table>
+
+  <nav id="pagination" aria-label="Page navigation">
+    <ul class="pagination justify-content-center">
+      <li class="page-item"><a class="page-link" href="#">Previous</a></li>
+      <li class="page-item"><a class="page-link" href="#">1</a></li>
+      <li class="page-item"><a class="page-link" href="#">Next</a></li>
+    </ul>
+  </nav>
+
+</main>
+
+<footer id="footer">
+  <hr>
+  푸터 삽입부
+</footer>
+
+<script src="https://cdn.jsdelivr.net/npm/bootstrap@5.2.0-beta1/dist/js/bootstrap.bundle.min.js" integrity="sha384-pprn3073KE6tl6bjs2QrFaJGz5/SUsLqktiwsUTF55Jfv3qYSDhgCecCxMW52nD2" crossorigin="anonymous"></script>
+</body>
+</html>

--- a/project-board/src/main/resources/templates/articles/search-hashtag.th.xml
+++ b/project-board/src/main/resources/templates/articles/search-hashtag.th.xml
@@ -1,0 +1,78 @@
+<?xml version="1.0"?>
+<thlogic>
+  <attr sel="#header" th:replace="header :: header" />
+  <attr sel="#footer" th:replace="footer :: footer" />
+
+  <attr sel="main" th:object="${articles}">
+    <attr sel="#hashtags" th:remove="all-but-first">
+      <attr sel="div" th:each="hashtag : ${hashtags}">
+        <attr sel="a" th:class="'text-reset'" th:text="${hashtag}" th:href="@{/articles/search-hashtag(
+            page=${param.page},
+            sort=${param.sort},
+            searchType=${searchType.name},
+            searchValue=${hashtag}
+        )}" />
+      </attr>
+    </attr>
+
+    <attr sel="#article-table">
+      <attr sel="thead/tr">
+        <attr sel="th.title/a" th:text="'제목'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='title' + (*{sort.getOrderFor('title')} != null ? (*{sort.getOrderFor('title').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+        <attr sel="th.content/a" th:text="'본문'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='content' + (*{sort.getOrderFor('content')} != null ? (*{sort.getOrderFor('content').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+        <attr sel="th.user-id/a" th:text="'작성자'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='userAccount.userId' + (*{sort.getOrderFor('userAccount.userId')} != null ? (*{sort.getOrderFor('userAccount.userId').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+        <attr sel="th.created-at/a" th:text="'작성일'" th:href="@{/articles/search-hashtag(
+            page=${articles.number},
+            sort='createdAt' + (*{sort.getOrderFor('createdAt')} != null ? (*{sort.getOrderFor('createdAt').direction.name} != 'DESC' ? ',desc' : '') : ''),
+            searchType=${searchType.name},
+            searchValue=${param.searchValue}
+        )}"/>
+      </attr>
+      <attr sel="tbody" th:remove="all-but-first">
+        <attr sel="tr[0]" th:each="article : ${articles}">
+          <attr sel="td.title/a" th:text="${article.title}" th:href="@{'/articles/' + ${article.id}}" />
+          <attr sel="td.content/span" th:text="${article.content}" />
+          <attr sel="td.user-id" th:text="${article.nickname}" />
+          <attr sel="td.created-at/time" th:datetime="${article.createdAt}" th:text="${#temporals.format(article.createdAt, 'yyyy-MM-dd')}" />
+        </attr>
+      </attr>
+    </attr>
+
+
+    <attr sel="#pagination">
+      <attr sel="ul">
+        <attr sel="li[0]/a"
+              th:text="'previous'"
+              th:href="@{/articles(page=${articles.number - 1}, sort=${param.sort}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+              th:class="'page-link' + (${articles.number} <= 0 ? ' disabled' : '')"
+        />
+        <attr sel="li[1]" th:class="page-item" th:each="pageNumber : ${paginationBarNumbers}">
+          <attr sel="a"
+                th:text="${pageNumber + 1}"
+                th:href="@{/articles(page=${pageNumber}, sort=${param.sort}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+                th:class="'page-link' + (${pageNumber} == ${articles.number} ? ' disabled' : '')"
+          />
+        </attr>
+        <attr sel="li[2]/a"
+              th:text="'next'"
+              th:href="@{/articles(page=${articles.number + 1}, sort=${param.sort}, searchType=${searchType.name}, searchValue=${param.searchValue})}"
+              th:class="'page-link' + (${articles.number} >= ${articles.totalPages - 1} ? ' disabled' : '')"
+        />
+      </attr>
+    </attr>
+  </attr>
+</thlogic>

--- a/project-board/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
+++ b/project-board/src/test/java/com/fastcampus/projectboard/service/ArticleServiceTest.java
@@ -18,6 +18,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -62,7 +63,52 @@ class ArticleServiceTest {
 
         // Then
         assertThat(articles).isEmpty();
-        then(articleRepository).should().findByTitleContaining(searchKeyword, pageable);
+        then(articleRepository).should().findByTitleContaining(searchKeyword, pageable);        // 영속성 repository 관련 테스트
+    }
+
+    @DisplayName("검색어 없이 게시글을 해시태그 검색하면, 빈 페이지를 반환한다.")
+    @Test
+    void givenNoSearchParameters_whenSearchingArticlesViaHashtag_thenReturnsEmptyPage() {
+        // Given
+        Pageable pageable = Pageable.ofSize(20);
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesViaHashtag(null, pageable);
+
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).shouldHaveNoInteractions();
+    }
+
+    @DisplayName("게시글을 해시태그 검색하면, 게시글 페이지를 반환한다.")
+    @Test
+    void givenHashtags_whenSearchingArticlesViaHashtag_thenReturnsArticlePage() {
+        // Given
+        String hashtag = "#java";
+        Pageable pageable = Pageable.ofSize(20);
+        given(articleRepository.findByHashtag(hashtag, pageable)).willReturn(Page.empty(pageable));
+
+        // When
+        Page<ArticleDto> articles = sut.searchArticlesViaHashtag(hashtag, pageable);
+
+        // Then
+        assertThat(articles).isEqualTo(Page.empty(pageable));
+        then(articleRepository).should().findByHashtag(hashtag, pageable);
+    }
+
+    @DisplayName("해시태그를 조회하면, 유니크 해시태그 리스트를 반환한다.")
+    @Test
+    void givenNothing_whenCalling_thenReturnsHashtags() {
+        // Given
+        List<String> expectedHashtags = List.of("#java", "#spring", "#boot");
+        given(articleRepository.findAllDistinctHashtags()).willReturn(expectedHashtags);
+
+        // When
+        List<String> actualHashtags = sut.getHashtags();
+
+        // Then
+        assertThat(actualHashtags).isEqualTo(expectedHashtags);
+        then(articleRepository).should().findAllDistinctHashtags();
     }
 
     @DisplayName("게시글을 조회하면, 게시글을 반환한다.")


### PR DESCRIPTION
해시태그 페이지와 관련 기능 구현

- 코드리뷰를 보는 사람이 이해하기 쉽도록 pull request의 메시지를 디테일하게 쓸 것.

This closes #27 
