### PR TITLE
#48-대댓글 도메인 설계

### DIFF
--- a/project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
+++ b/project-board/src/main/java/com/fastcampus/projectboard/domain/ArticleComment.java
@@ -4,8 +4,11 @@ import jakarta.persistence.*;
 import lombok.Getter;
 import lombok.Setter;
 import lombok.ToString;
+import org.springframework.boot.actuate.endpoint.web.Link;
 
+import java.util.LinkedHashSet;
 import java.util.Objects;
+import java.util.Set;
 
 @Getter
 @ToString(callSuper = true)
@@ -24,19 +27,34 @@ public class ArticleComment extends AuditingFields {
     @Setter @ManyToOne(optional = false) private Article article; // 게시글 (ID)
     @Setter @ManyToOne(optional = false) @JoinColumn(name = "userId") private UserAccount userAccount; // 유저 정보 (ID)
 
+    @Setter
+    @Column(nullable = true, updatable = false)
+    private Long parentCommentId;                                   // 부모 댓글 id
+
+    @ToString.Exclude
+    @OrderBy("createdAt ASC")
+    @OneToMany(mappedBy = "parentCommentId", cascade = CascadeType.ALL)     // 부모댓글이 지워지면 자식댓글은 cascade로 삭제.
+    private Set<ArticleComment> childComments = new LinkedHashSet<>();
+
     @Setter @Column(nullable = false, length = 500) private String content; // 본문
 
 
     protected ArticleComment() {}
 
-    private ArticleComment(Article article, UserAccount userAccount, String content) {
+    private ArticleComment(Article article, UserAccount userAccount, Long parentCommentId, String content) {
         this.article = article;
         this.userAccount = userAccount;
+        this.parentCommentId = parentCommentId;
         this.content = content;
     }
 
     public static ArticleComment of(Article article, UserAccount userAccount, String content) {
-        return new ArticleComment(article, userAccount, content);
+        return new ArticleComment(article, userAccount, null, content);
+    }
+
+    public void addChildComment(ArticleComment child) {
+        child.setParentCommentId(this.id);
+        this.getChildComments().add(child);
     }
 
     @Override


### PR DESCRIPTION
대댓글 도메인 안에서 부모, 자식 관계를 설정하는 코드를 추가
자식 댓글의 컬렉션 변화가 쿼리에 반영되게끔
cascading 규칙을 모두( ALL ) 적용
이번엔 단방향 연관관계 설정을 사용해보기로 함
따라서 부모 댓글은 엔티티가 아닌 'Long' id를 직접 표현

또한 자식 댓글을 추가할 수 있는 메소드 추가.

이 pr은 1차 대댓글 도메인 개발을 위해 도메인을 업데이트 한다.

This closes #48 